### PR TITLE
Separate python and xspec interface for MCVSPEC to eliminate dependance on HEAsoft (except for when desired)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.15)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(BUILD_PYBINDINGS True CACHE BOOL "Build pyMCVSPEC")
+set(BUILD_XSMODEL True CACHE BOOL "Build XSpec Model")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 project(mcvspec VERSION 1.0.0)
@@ -21,25 +22,27 @@ add_custom_command(
 
 add_custom_target(embed_wd_mass_radius DEPENDS ${MR_HEADER_PATH})
 
-if(NOT DEFINED ENV{HEADAS})
-    message(FATAL_ERROR "HEADAS must be defined and point to your installation of HEASoft")
-endif()
-
-# gather info about HEASOFT env, reproduce logic of build naming
-set(HEADAS "$ENV{HEADAS}/")
-get_filename_component(HEASOFT_DIR "${HEADAS}" DIRECTORY)
-execute_process (COMMAND bash -c
-    ". ${HEASOFT_DIR}/BUILD_DIR/config.guess"
-    OUTPUT_VARIABLE HEA_SYS_GUESS)
-execute_process (COMMAND bash -c
-    ". ${HEASOFT_DIR}/BUILD_DIR/config.sub ${HEA_SYS_GUESS}"
-    OUTPUT_VARIABLE HEA_SYSTEM_NAME)
-string(STRIP "${HEA_SYSTEM_NAME}" HEA_SYSTEM_NAME)
-
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     set(CMAKE_INSTALL_PREFIX
     "${CMAKE_BINARY_DIR}" CACHE PATH "MCVSPEC install prefix" FORCE)
 endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+
+if(BUILD_XSMODEL)
+    if(NOT DEFINED ENV{HEADAS})
+        message(FATAL_ERROR "HEADAS must be defined and point to your installation of HEASoft")
+    endif()
+
+    # gather info about HEASOFT env, reproduce logic of build naming
+    set(HEADAS "$ENV{HEADAS}/")
+    get_filename_component(HEASOFT_DIR "${HEADAS}" DIRECTORY)
+    execute_process (COMMAND bash -c
+        ". ${HEASOFT_DIR}/BUILD_DIR/config.guess"
+        OUTPUT_VARIABLE HEA_SYS_GUESS)
+    execute_process (COMMAND bash -c
+        ". ${HEASOFT_DIR}/BUILD_DIR/config.sub ${HEA_SYS_GUESS}"
+        OUTPUT_VARIABLE HEA_SYSTEM_NAME)
+    string(STRIP "${HEA_SYSTEM_NAME}" HEA_SYSTEM_NAME)
+endif()
 
 if(BUILD_PYBINDINGS)
     find_package(pybind11 CONFIG REQUIRED)
@@ -53,52 +56,46 @@ if(BUILD_PYBINDINGS)
     # MCVSPEC Headers
     target_include_directories(_pymcvspec PUBLIC "${PROJECT_SOURCE_DIR}/include" ${CMAKE_CURRENT_BINARY_DIR})
 
-    # HEASOFT Headers
-    target_include_directories(_pymcvspec PUBLIC
-        "${HEASOFT_DIR}/Xspec/${HEA_SYSTEM_NAME}/include"
-        "${HEASOFT_DIR}/Xspec/${HEA_SYSTEM_NAME}/include/XSFunctions"
-        "${HEASOFT_DIR}/Xspec/${HEA_SYSTEM_NAME}/include/XSFunctions/Utilities"
-        "${HEASOFT_DIR}/heacore/${HEA_SYSTEM_NAME}/include"
-        "${HEASOFT_DIR}/tcltk/${HEA_SYSTEM_NAME}/include"
-    )
-    target_link_libraries(_pymcvspec PRIVATE "${HEASOFT_DIR}/Xspec/${HEA_SYSTEM_NAME}/lib/libXSFunctions.dylib")
     set(PYMCVSPEC_DIR "${CMAKE_INSTALL_PREFIX}/pymcvspec")
     install(TARGETS _pymcvspec DESTINATION ${PYMCVSPEC_DIR})
     install(FILES ${PROJECT_SOURCE_DIR}/pymcvspec/mcvspec.py DESTINATION ${PYMCVSPEC_DIR})
     target_compile_definitions(_pymcvspec PRIVATE)
 endif()
 
-# compile xspec model
-set(XSPEC_MODEL_DIR "${CMAKE_INSTALL_PREFIX}/xspec")
-file(MAKE_DIRECTORY "${XSPEC_MODEL_DIR}")
+if(BUILD_XSMODEL)
+    # compile xspec model
+    set(XSPEC_MODEL_DIR "${CMAKE_INSTALL_PREFIX}/xspec")
+    file(MAKE_DIRECTORY "${XSPEC_MODEL_DIR}")
 
-set(SOURCE_FILES ${CMAKE_SOURCE_DIR}/source/Cataclysmic_Variable.cpp;
-                 ${CMAKE_SOURCE_DIR}/source/integration.cpp)
-set(MODEL_FILES ${CMAKE_SOURCE_DIR}/model_funcs/polarspec.cpp;
-                ${CMAKE_SOURCE_DIR}/model_funcs/ipsepc.cpp;
-                ${CMAKE_SOURCE_DIR}/model_funcs/mcvspec.dat)
-set(HEADER_FILES ${CMAKE_SOURCE_DIR}/include/Cataclysmic_Variable.hh;
-                 ${CMAKE_SOURCE_DIR}/include/integration.hh;
-                 ${CMAKE_SOURCE_DIR}/include/constants.hh;
-                 ${CMAKE_SOURCE_DIR}/include/tableau.hh;
-                 ${MR_HEADER_PATH})
+    set(SOURCE_FILES ${CMAKE_SOURCE_DIR}/source/Cataclysmic_Variable.cpp;
+                    ${CMAKE_SOURCE_DIR}/source/XS_Cataclysmic_Variable.cpp;
+                    ${CMAKE_SOURCE_DIR}/source/integration.cpp)
+    set(MODEL_FILES ${CMAKE_SOURCE_DIR}/model_funcs/polarspec.cpp;
+                    ${CMAKE_SOURCE_DIR}/model_funcs/ipsepc.cpp;
+                    ${CMAKE_SOURCE_DIR}/model_funcs/mcvspec.dat)
+    set(HEADER_FILES ${CMAKE_SOURCE_DIR}/include/Cataclysmic_Variable.hh;
+                    ${CMAKE_SOURCE_DIR}/include/integration.hh;
+                    ${CMAKE_SOURCE_DIR}/include/constants.hh;
+                    ${CMAKE_SOURCE_DIR}/include/tableau.hh;
+                    ${MR_HEADER_PATH})
 
-foreach(FILE IN LISTS SOURCE_FILES MODEL_FILES HEADER_FILES)
-    get_filename_component(FNAME "${FILE}" NAME)
-    file(CREATE_LINK "${FILE}" "${XSPEC_MODEL_DIR}/${FNAME}" SYMBOLIC)
-endforeach()
+    foreach(FILE IN LISTS SOURCE_FILES MODEL_FILES HEADER_FILES)
+        get_filename_component(FNAME "${FILE}" NAME)
+        file(CREATE_LINK "${FILE}" "${XSPEC_MODEL_DIR}/${FNAME}" SYMBOLIC)
+    endforeach()
 
-# clean up xspec dir if still has old files
-if(EXISTS "${XSPEC_MODEL_DIR}/lpack_mcvspec.cxx")
-    file(REMOVE "${XSPEC_MODEL_DIR}/lpack_mcvspec.cxx")
+    # clean up xspec dir if still has old files
+    if(EXISTS "${XSPEC_MODEL_DIR}/lpack_mcvspec.cxx")
+        file(REMOVE "${XSPEC_MODEL_DIR}/lpack_mcvspec.cxx")
+    endif()
+
+    execute_process (COMMAND bash -c "initpackage mcvspec ${XSPEC_MODEL_DIR}/mcvspec.dat ${XSPEC_MODEL_DIR}")
+
+    add_custom_command(
+        OUTPUT "${XSPEC_MODEL_DIR}/hmake.log"
+        COMMAND bash -c "hmake > hmake.log"
+        WORKING_DIRECTORY ${XSPEC_MODEL_DIR}
+        COMMENT "Building XSPEC Model"
+    )
+    add_custom_target(mcvspec_xspec ALL DEPENDS "${XSPEC_MODEL_DIR}/hmake.log" VERBATIM)
 endif()
-
-execute_process (COMMAND bash -c "initpackage mcvspec ${XSPEC_MODEL_DIR}/mcvspec.dat ${XSPEC_MODEL_DIR}")
-
-add_custom_command(
-    OUTPUT "${XSPEC_MODEL_DIR}/hmake.log"
-    COMMAND bash -c "hmake > hmake.log"
-    WORKING_DIRECTORY ${XSPEC_MODEL_DIR}
-    COMMENT "Building XSPEC Model"
-)
-add_custom_target(mcvspec_xspec ALL DEPENDS "${XSPEC_MODEL_DIR}/hmake.log" VERBATIM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ if(BUILD_XSMODEL)
                     ${CMAKE_SOURCE_DIR}/model_funcs/ipsepc.cpp;
                     ${CMAKE_SOURCE_DIR}/model_funcs/mcvspec.dat)
     set(HEADER_FILES ${CMAKE_SOURCE_DIR}/include/Cataclysmic_Variable.hh;
+                    ${CMAKE_SOURCE_DIR}/include/XS_Cataclysmic_Variable.hh;
                     ${CMAKE_SOURCE_DIR}/include/integration.hh;
                     ${CMAKE_SOURCE_DIR}/include/constants.hh;
                     ${CMAKE_SOURCE_DIR}/include/tableau.hh;

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ## Introduction
 MCVSPEC is a model for the post-shock accretion flow in magnetic Cataclysmic Variables (mCVs).
-It solves for the full thermal profile of the post-shock accretion column (PSAC) and produces an X-Ray spectrum by convolving the thermal profile with the optically-thin thermal bremsstrahlung spectrum produced by APEC. Additioanlly, MCVSPEC is capable of reflecting the PSAC column off the WD surface.
+It solves for the full thermal profile of the post-shock accretion column (PSAC) and can produce an X-Ray spectrum from that profile. Currently MCVSPEC supports two interfaces: python and xspec. These interfaces are not totally equivalent (in particular the python interface provides more flexible accsess to the thermal profiles while the xspec interface provides a more accurate spectrum) so it is recommended that both are installed where possible.
+
+## XSPEC Interface
 
 MCVSPEC contains two models: `polarspec` and `ipsepc` which are used for their respective class of objects. Both models share the common inputs:
 
@@ -27,11 +29,16 @@ The magnetic field strength is determined differently for each class of mCV.
 
 Additionally, the accretion area can be specified in one of two ways. Either (in the case of `ipsepc` and `polarspec`) the fractional accretion area (`f`) can be specified or (in the case of `aripsepc` and `arpolarspec`)the accretion area (A) in units of 10<sup>15</sup> cm<sup>2</sup>.
 
+## Python Interface
+
+MCVSPECs python interface utilizes `AtomDB`s python api to generate the primary thermal X-Ray spectrum but has no implementation for X-Ray reflection at this time.
+
 ## Dependencies
-* [HEASOFT](https://heasarc.gsfc.nasa.gov/docs/software/lheasoft/)
 * CMake
 * Python
-### Additional Dependencies For pybindings (strongly recommended)
+### XSPEC Interface
+* [HEASOFT](https://heasarc.gsfc.nasa.gov/docs/software/lheasoft/)
+### Python Interface
 * [Pybind11](https://pybind11.readthedocs.io/en/stable/)
 * [NumPy](https://numpy.org)
 * [Astropy](https://docs.astropy.org/en/stable/index.html)
@@ -43,26 +50,26 @@ Additionally, the accretion area can be specified in one of two ways. Either (in
 We will assume that the repository is located in `/path/to/MCVSPEC`. You will also want to create a build directory (`/path/to/MCVSPEC/build` is fine, but it can be anywhere)
 
 ### Build MCVSPEC
-`HEASoft` must be initialized and (optionally but highly recommended) the virtual environment you wish to install pyMCVSPEC to should be activated.
-
 From your build directory execute
 
 `cmake /path/to/MCVSPEC` (optionally specify an installation directory with `-DCMAKE_INSTALL_PREFIX`)
 
-`make`
+By default both the python and xspec interface will be built which require that cmake can find `HEASoft` and `pybind11` respectively. `HEASoft` is found through `$HEADAS` environmental variable. If you would like to turn off either of the interfaces it can be done with the cmake variables BUILD_PYBINDINGS and
+BUILD_XSMODEL.
 
-`make install`
+After cmake configures your build simply run `make` and `make install`.
 
 `cmake` will execute the `HEASoft` utility `initpackage` supplying your install directory with the necessary build files.
 `make` will execute `hmake` producing the mcvspec xspec library.
 
 ### Initialize Package
 If installing pyMCVSPEC simply add `/path/to/install/pymcvspec` to your `$PYTHONPATH`
+For the XSPEC interface one can run, from the xspec prompt, `lmod mcvspec /path/to/install/xspec` to load the mcvspec models into their xspec session. If you would like to configure XSPEC to load mcvspec on start you can always add `load /path/to/install/xspec/libmcvspec.dylib` the `global_customize.tcl` file in `HEASoft` (described in the "Customizing system-wide" section of the XSPEC manual)
 
 ## Usage
 
 ### Load the mcvspec models in xspec
-From the xspec prompt run `lmod mcvspec /path/to/install/xspec` to load the mcvspec models. You can then choose between `polarspec`, `ipsepc`, `apolarspec`, or `aipspec` depending on your source.
+Once loaded into XSPEC you can then choose between `polarspec`, `ipsepc`, `apolarspec`, or `aipspec` depending on your source.
 
 To load the python module:
 ```python

--- a/include/Cataclysmic_Variable.hh
+++ b/include/Cataclysmic_Variable.hh
@@ -36,7 +36,7 @@ class Cataclysmic_Variable{
         static double Get_Accretion_Rate(double, double, double, double);
 
     protected:
-        virtual void Set_Abundances() = 0;
+        virtual void Set_Abundances(double) = 0;
         void Set_Cooling_Constants();
         void Guess_Shock_Height();
         void Update_Shock_Height(double);

--- a/include/Cataclysmic_Variable.hh
+++ b/include/Cataclysmic_Variable.hh
@@ -37,7 +37,7 @@ class Cataclysmic_Variable{
         static double Get_Accretion_Rate(double, double, double, double);
 
     protected:
-        virtual void Set_Abundances();
+        virtual void Set_Abundances() = 0;
         void Set_Cooling_Constants();
         void Guess_Shock_Height();
         void Update_Shock_Height(double);

--- a/include/Cataclysmic_Variable.hh
+++ b/include/Cataclysmic_Variable.hh
@@ -3,9 +3,6 @@
 #include "constants.hh"
 #include "integration.hh"
 #include <valarray>
-#include <xsTypes.h>
-#include <funcWrappers.h>
-#include <XSFunctions/Utilities/FunctionUtility.h>
 
 class Cataclysmic_Variable{
     protected:
@@ -34,13 +31,13 @@ class Cataclysmic_Variable{
         valarray<double> Flow_Equation(double vel, valarray<double> pos);
         void Shock_Height_Shooting();
         void Build_Column_Profile();
-        void MCVspec_Spectrum(const RealArray& energy, const int spectrum_num, RealArray& flux, const string& init_string);
         void Print_Properties();
 
         static double Get_Radius(double);
         static double Get_Accretion_Rate(double, double, double, double);
 
     protected:
+        virtual void Set_Abundances();
         void Set_Cooling_Constants();
         void Guess_Shock_Height();
         void Update_Shock_Height(double);

--- a/include/Cataclysmic_Variable.hh
+++ b/include/Cataclysmic_Variable.hh
@@ -26,7 +26,6 @@ class Cataclysmic_Variable{
     public:
         Cataclysmic_Variable(double,double,double,double,double,double,double,double,double,int);
         Cataclysmic_Variable(double,double,double,double,double,double,double,double,double,double,int);
-        virtual void Set_Abundances(double);
 
         valarray<double> Flow_Equation(double vel, valarray<double> pos);
         void Shock_Height_Shooting();

--- a/include/XS_Cataclysmic_Variable.hh
+++ b/include/XS_Cataclysmic_Variable.hh
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "Cataclysmic_Variable.hh"
+#include <XSFunctions/Utilities/FunctionUtility.h>
+#include <xsTypes.h>
+#include <funcWrappers.h>
+#include <XSFunctions/Utilities/FunctionUtility.h>
+
+class XS_Cataclysmic_Variable : public Cataclysmic_Variable {
+    public:
+        XS_Cataclysmic_Variable(double,double,double,double,double,double,double,double,double,double,int);
+        void XS_Spectrum(const RealArray&, const int, RealArray&, const string&);
+    protected:
+        void Set_Abundances(double);
+};

--- a/include/XS_Cataclysmic_Variable.hh
+++ b/include/XS_Cataclysmic_Variable.hh
@@ -11,5 +11,5 @@ class XS_Cataclysmic_Variable : public Cataclysmic_Variable {
         XS_Cataclysmic_Variable(double,double,double,double,double,double,double,double,double,double,int);
         void XS_Spectrum(const RealArray&, const int, RealArray&, const string&);
     protected:
-        void Set_Abundances(double);
+        void Set_Abundances(double) override;
 };

--- a/model_funcs/ipsepc.cpp
+++ b/model_funcs/ipsepc.cpp
@@ -25,11 +25,11 @@ void IPspec(const RealArray& energy, const RealArray& params, int spectrum_num, 
     double mdot = Cataclysmic_Variable::Get_Accretion_Rate(luminosity, mass, radius, inverse_mag_radius);
     double b_field = sqrt(32*mdot*sqrt(grav_const*mass/pow(inverse_mag_radius,7)))/(radius*radius*radius);
 
-    Cataclysmic_Variable polar(mass, radius, b_field, mdot, inverse_mag_radius, col_abund, area, cos_incl, area_exponent, source_distance, reflection_sel);
-    polar.Shock_Height_Shooting();
-    polar.Build_Column_Profile();
-    polar.MCVspec_Spectrum(energy, spectrum_num, flux, init_string);
-    polar.Print_Properties();
+    XS_Cataclysmic_Variable intermediate_polar(mass, radius, b_field, mdot, inverse_mag_radius, col_abund, area, cos_incl, area_exponent, source_distance, reflection_sel);
+    intermediate_polar.Shock_Height_Shooting();
+    intermediate_polar.Build_Column_Profile();
+    intermediate_polar.XS_Spectrum(energy, spectrum_num, flux, init_string);
+    intermediate_polar.Print_Properties();
 }
 
 extern "C"
@@ -54,9 +54,9 @@ void IPspecArea(const RealArray& energy, const RealArray& params, int spectrum_n
     double mdot = Cataclysmic_Variable::Get_Accretion_Rate(luminosity, mass, radius, inverse_mag_radius);
     double b_field = sqrt(32*mdot*sqrt(grav_const*mass/pow(inverse_mag_radius,7)))/(radius*radius*radius);
 
-    Cataclysmic_Variable polar(mass, radius, b_field, mdot, inverse_mag_radius, col_abund, area, cos_incl, area_exponent, source_distance, reflection_sel);
-    polar.Shock_Height_Shooting();
-    polar.Build_Column_Profile();
-    polar.MCVspec_Spectrum(energy, spectrum_num, flux, init_string);
-    polar.Print_Properties();
+    XS_Cataclysmic_Variable intermediate_polar(mass, radius, b_field, mdot, inverse_mag_radius, col_abund, area, cos_incl, area_exponent, source_distance, reflection_sel);
+    intermediate_polar.Shock_Height_Shooting();
+    intermediate_polar.Build_Column_Profile();
+    intermediate_polar.XS_Spectrum(energy, spectrum_num, flux, init_string);
+    intermediate_polar.Print_Properties();
 }

--- a/model_funcs/ipsepc.cpp
+++ b/model_funcs/ipsepc.cpp
@@ -1,4 +1,4 @@
-#include "Cataclysmic_Variable.hh"
+#include "XS_Cataclysmic_Variable.hh"
 #include "constants.hh"
 
 extern "C"

--- a/model_funcs/polarspec.cpp
+++ b/model_funcs/polarspec.cpp
@@ -1,4 +1,4 @@
-#include "Cataclysmic_Variable.hh"
+#include "XS_Cataclysmic_Variable.hh"
 
 extern "C"
 void Polarspec(const RealArray& energy, const RealArray& params, int spectrum_num, RealArray& flux, RealArray& err, const string& init_string)

--- a/model_funcs/polarspec.cpp
+++ b/model_funcs/polarspec.cpp
@@ -19,10 +19,10 @@ void Polarspec(const RealArray& energy, const RealArray& params, int spectrum_nu
     double radius = Cataclysmic_Variable::Get_Radius(mass);
     double area = fractional_area*4*pi*radius*radius;
     double mdot = Cataclysmic_Variable::Get_Accretion_Rate(luminosity, mass, radius, 0);
-    Cataclysmic_Variable polar(mass, radius, b_field, mdot, 0, col_abund, area, cos_incl, area_exponent, source_distance, reflection_sel);
+    XS_Cataclysmic_Variable polar(mass, radius, b_field, mdot, 0, col_abund, area, cos_incl, area_exponent, source_distance, reflection_sel);
     polar.Shock_Height_Shooting();
     polar.Build_Column_Profile();
-    polar.MCVspec_Spectrum(energy, spectrum_num, flux, init_string);
+    polar.XS_Spectrum(energy, spectrum_num, flux, init_string);
     polar.Print_Properties();
 }
 
@@ -44,9 +44,9 @@ void PolarspecArea(const RealArray& energy, const RealArray& params, int spectru
 
     double radius = Cataclysmic_Variable::Get_Radius(mass);
     double mdot = Cataclysmic_Variable::Get_Accretion_Rate(luminosity, mass, radius, 0);
-    Cataclysmic_Variable polar(mass, radius, b_field, mdot, 0, col_abund, area, cos_incl, area_exponent, source_distance, reflection_sel);
+    XS_Cataclysmic_Variable polar(mass, radius, b_field, mdot, 0, col_abund, area, cos_incl, area_exponent, source_distance, reflection_sel);
     polar.Shock_Height_Shooting();
     polar.Build_Column_Profile();
-    polar.MCVspec_Spectrum(energy, spectrum_num, flux, init_string);
+    polar.XS_Spectrum(energy, spectrum_num, flux, init_string);
     polar.Print_Properties();
 }

--- a/pymcvspec/bindings.cpp
+++ b/pymcvspec/bindings.cpp
@@ -22,7 +22,7 @@ class Py_Cataclysmic_Variable : public Cataclysmic_Variable {
             abundances.resize(atomic_charge.size());
             abundances = {1.00e+00, 9.77e-02, m*3.63e-04, m*1.12e-04, m*8.51e-04, m*1.23e-04,
                           m*3.80e-05, m*2.95e-06, m*3.55e-05, m*1.62e-05, m*3.63e-06, m*2.29e-06,
-                          m*4.68e-05, m*1.78e-06};
+                          m*4.68e-05, m*1.78e-06}; // taken from Anders & Grevesse (1989) DOI: 10.1016/0016-7037(89)90286-X
             abundances = abundances/abundances.sum();
             Set_Cooling_Constants();
         }

--- a/source/Cataclysmic_Variable.cpp
+++ b/source/Cataclysmic_Variable.cpp
@@ -4,7 +4,6 @@
 #include "mass_radius.hh"
 #include <cmath>
 #include <iostream>
-#include <XSFunctions/Utilities/FunctionUtility.h>
 
 using std::cout;
 using std::endl;
@@ -24,29 +23,6 @@ Cataclysmic_Variable::Cataclysmic_Variable(double m, double r, double b, double 
     if(inverse_mag_radius>0){
         b_field = sqrt(32*accretion_rate*sqrt(grav_const*mass/pow(inverse_mag_radius,7)))/(radius*radius*radius);
     }
-}
-
-Cataclysmic_Variable::Cataclysmic_Variable(double m, double r, double b, double mdot, double inv_r_m, double metals, double area, double theta, double n, double dist, int reflection):
-    mass(m), radius(r), b_field(b),  inverse_mag_radius(inv_r_m), distance(dist), accretion_rate(mdot), accretion_area(area), metalicity(metals), pressure_ratio(.75), incl_angle(theta), area_exponent(n),  refl(reflection),
-    accretion_column(Flow_Equation_Wrapper, this, 3)
-{
-    if(inverse_mag_radius>0){
-        b_field = sqrt(32*accretion_rate*sqrt(grav_const*mass/pow(inverse_mag_radius,7)))/(radius*radius*radius);
-    }
-    Set_Abundances(metalicity);
-    Guess_Shock_Height();
-}
-
-void Cataclysmic_Variable::Set_Abundances(double metalicity){
-    abundances.resize(atomic_charge.size());
-    abundances[0] = FunctionUtility::getAbundance(atomic_charge[0]);
-
-    abundances[1] = FunctionUtility::getAbundance(atomic_charge[1]);
-    for(int i = 2; i < 14; i++){
-        abundances[i] = metalicity*FunctionUtility::getAbundance(atomic_charge[i]);
-    }
-    abundances = abundances/abundances.sum();
-    Set_Cooling_Constants();
 }
 
 void Cataclysmic_Variable::Set_Cooling_Constants(){ // "constant" insofar as these values depend only on the input properties not on any derived properties
@@ -293,40 +269,6 @@ void Cataclysmic_Variable::Build_Column_Profile(){
     x1 = altitude[0];
     volume[0] = accretion_area*radius*pow(1+x1/radius,area_exponent+1)/(area_exponent+1);
     volume[0] -= accretion_area*radius*pow(1+x0/radius,area_exponent+1)/(area_exponent+1);
-}
-
-void Cataclysmic_Variable::MCVspec_Spectrum(const RealArray& energy, const int spectrum_num, RealArray& flux, const string& init_string){
-    int n = flux.size();
-    double refl_amp;
-    valarray<double> apec_flux(n);
-    valarray<double> reflected_flux(n);
-    valarray<double> flux_error(n);
-    valarray<double> apec_parameters = {0,metalicity,0};
-    valarray<double> refl_parameters = {-1,0,metalicity,metalicity,incl_angle};
-    // refl_amp = -1 means only return reflected spectrum, this ensures that reflection can be done separately to apec
-
-    for(int i=0; i<altitude.size(); i++){
-        apec_parameters[0] = electron_temperature[i];
-        if (apec_parameters[0] > 64.0){
-            CXX_bremss(energy, apec_parameters, spectrum_num, apec_flux, flux_error, init_string);
-        }
-        else{
-            CXX_apec(energy, apec_parameters, spectrum_num, apec_flux, flux_error, init_string);
-        }
-        apec_flux *= volume[i]*ion_density[i]*electron_density[i]*1e-14;
-        apec_flux /= 4*pi*distance*distance;
-        flux += apec_flux;
-
-        if(refl==1){
-            refl_amp = 1-sqrt(1.0-1.0/pow(1+altitude[i]/radius,2));
-            reflected_flux += refl_amp*apec_flux;
-        }
-        apec_flux *= 0;
-    }
-    if(refl==1){
-        CXX_reflect(energy, refl_parameters, spectrum_num, reflected_flux, flux_error, init_string);
-        flux += reflected_flux;
-    }
 }
 
 void Cataclysmic_Variable::Print_Properties(){

--- a/source/XS_Cataclysmic_Variable.cpp
+++ b/source/XS_Cataclysmic_Variable.cpp
@@ -1,65 +1,57 @@
-#include "Cataclysmic_Variable.hh"
-#include "constants.hh"
-#include <XSFunctions/Utilities/FunctionUtility.h>
-#include <xsTypes.h>
-#include <funcWrappers.h>
-#include <XSFunctions/Utilities/FunctionUtility.h>
+#include "XS_Cataclysmic_Variable.hh"
 
-class XS_Cataclysmic_Variable : public Cataclysmic_Variable {
+XS_Cataclysmic_Variable::XS_Cataclysmic_Variable(double m, double r, double b, double mdot, double inv_r_m, double metals, double area, double theta, double n, double dist, int reflection):
+    Cataclysmic_Variable(m,r,b,mdot,inv_r_m,area,theta,n,dist,reflection)
+{
+    metalicity = metals;
+    Set_Abundances(metals);
+    Guess_Shock_Height();
+    Shock_Height_Shooting();
+    Build_Column_Profile();
+}
 
-    XS_Cataclysmic_Variable(double m, double r, double b, double mdot, double inv_r_m, double metals, double area, double theta, double n, double dist, int reflection):
-        Cataclysmic_Variable(m,r,b,mdot,inv_r_m,area,theta,n,dist,reflection)
-    {
-        metalicity = metals;
-        Set_Abundances(metals);
-        Guess_Shock_Height();
-        Shock_Height_Shooting();
-        Build_Column_Profile();
+void XS_Cataclysmic_Variable::Set_Abundances(double metalicity){
+    abundances.resize(atomic_charge.size());
+    abundances[0] = FunctionUtility::getAbundance(atomic_charge[0]);
+
+    abundances[1] = FunctionUtility::getAbundance(atomic_charge[1]);
+    for(int i = 2; i < 14; i++){
+        abundances[i] = metalicity*FunctionUtility::getAbundance(atomic_charge[i]);
     }
+    abundances = abundances/abundances.sum();
+    Set_Cooling_Constants();
+}
 
-    void Set_Abundances(double metalicity){
-        abundances.resize(atomic_charge.size());
-        abundances[0] = FunctionUtility::getAbundance(atomic_charge[0]);
+void XS_Cataclysmic_Variable::XS_Spectrum(const RealArray& energy, const int spectrum_num, RealArray& flux, const string& init_string){
+    int n = flux.size();
+    double refl_amp;
+    valarray<double> apec_flux(n);
+    valarray<double> reflected_flux(n);
+    valarray<double> flux_error(n);
+    valarray<double> apec_parameters = {0,metalicity,0};
+    valarray<double> refl_parameters = {-1,0,metalicity,metalicity,incl_angle};
+    // refl_amp = -1 means only return reflected spectrum, this ensures that reflection can be done separately to apec
 
-        abundances[1] = FunctionUtility::getAbundance(atomic_charge[1]);
-        for(int i = 2; i < 14; i++){
-            abundances[i] = metalicity*FunctionUtility::getAbundance(atomic_charge[i]);
+    for(int i=0; i<altitude.size(); i++){
+        apec_parameters[0] = electron_temperature[i];
+        if (apec_parameters[0] > 64.0){
+            CXX_bremss(energy, apec_parameters, spectrum_num, apec_flux, flux_error, init_string);
         }
-        abundances = abundances/abundances.sum();
-        Set_Cooling_Constants();
-    }
-
-    void XS_Spectrum(const RealArray& energy, const int spectrum_num, RealArray& flux, const string& init_string){
-        int n = flux.size();
-        double refl_amp;
-        valarray<double> apec_flux(n);
-        valarray<double> reflected_flux(n);
-        valarray<double> flux_error(n);
-        valarray<double> apec_parameters = {0,metalicity,0};
-        valarray<double> refl_parameters = {-1,0,metalicity,metalicity,incl_angle};
-        // refl_amp = -1 means only return reflected spectrum, this ensures that reflection can be done separately to apec
-
-        for(int i=0; i<altitude.size(); i++){
-            apec_parameters[0] = electron_temperature[i];
-            if (apec_parameters[0] > 64.0){
-                CXX_bremss(energy, apec_parameters, spectrum_num, apec_flux, flux_error, init_string);
-            }
-            else{
-                CXX_apec(energy, apec_parameters, spectrum_num, apec_flux, flux_error, init_string);
-            }
-            apec_flux *= volume[i]*ion_density[i]*electron_density[i]*1e-14;
-            apec_flux /= 4*pi*distance*distance;
-            flux += apec_flux;
-
-            if(refl==1){
-                refl_amp = 1-sqrt(1.0-1.0/pow(1+altitude[i]/radius,2));
-                reflected_flux += refl_amp*apec_flux;
-            }
-            apec_flux *= 0;
+        else{
+            CXX_apec(energy, apec_parameters, spectrum_num, apec_flux, flux_error, init_string);
         }
+        apec_flux *= volume[i]*ion_density[i]*electron_density[i]*1e-14;
+        apec_flux /= 4*pi*distance*distance;
+        flux += apec_flux;
+
         if(refl==1){
-            CXX_reflect(energy, refl_parameters, spectrum_num, reflected_flux, flux_error, init_string);
-            flux += reflected_flux;
+            refl_amp = 1-sqrt(1.0-1.0/pow(1+altitude[i]/radius,2));
+            reflected_flux += refl_amp*apec_flux;
         }
+        apec_flux *= 0;
     }
-};
+    if(refl==1){
+        CXX_reflect(energy, refl_parameters, spectrum_num, reflected_flux, flux_error, init_string);
+        flux += reflected_flux;
+    }
+}

--- a/source/XS_Cataclysmic_Variable.cpp
+++ b/source/XS_Cataclysmic_Variable.cpp
@@ -1,0 +1,65 @@
+#include "Cataclysmic_Variable.hh"
+#include "constants.hh"
+#include <XSFunctions/Utilities/FunctionUtility.h>
+#include <xsTypes.h>
+#include <funcWrappers.h>
+#include <XSFunctions/Utilities/FunctionUtility.h>
+
+class XS_Cataclysmic_Variable : public Cataclysmic_Variable {
+
+    XS_Cataclysmic_Variable(double m, double r, double b, double mdot, double inv_r_m, double metals, double area, double theta, double n, double dist, int reflection):
+        Cataclysmic_Variable(m,r,b,mdot,inv_r_m,area,theta,n,dist,reflection)
+    {
+        metalicity = metals;
+        Set_Abundances(metals);
+        Guess_Shock_Height();
+        Shock_Height_Shooting();
+        Build_Column_Profile();
+    }
+
+    void Set_Abundances(double metalicity){
+        abundances.resize(atomic_charge.size());
+        abundances[0] = FunctionUtility::getAbundance(atomic_charge[0]);
+
+        abundances[1] = FunctionUtility::getAbundance(atomic_charge[1]);
+        for(int i = 2; i < 14; i++){
+            abundances[i] = metalicity*FunctionUtility::getAbundance(atomic_charge[i]);
+        }
+        abundances = abundances/abundances.sum();
+        Set_Cooling_Constants();
+    }
+
+    void XS_Spectrum(const RealArray& energy, const int spectrum_num, RealArray& flux, const string& init_string){
+        int n = flux.size();
+        double refl_amp;
+        valarray<double> apec_flux(n);
+        valarray<double> reflected_flux(n);
+        valarray<double> flux_error(n);
+        valarray<double> apec_parameters = {0,metalicity,0};
+        valarray<double> refl_parameters = {-1,0,metalicity,metalicity,incl_angle};
+        // refl_amp = -1 means only return reflected spectrum, this ensures that reflection can be done separately to apec
+
+        for(int i=0; i<altitude.size(); i++){
+            apec_parameters[0] = electron_temperature[i];
+            if (apec_parameters[0] > 64.0){
+                CXX_bremss(energy, apec_parameters, spectrum_num, apec_flux, flux_error, init_string);
+            }
+            else{
+                CXX_apec(energy, apec_parameters, spectrum_num, apec_flux, flux_error, init_string);
+            }
+            apec_flux *= volume[i]*ion_density[i]*electron_density[i]*1e-14;
+            apec_flux /= 4*pi*distance*distance;
+            flux += apec_flux;
+
+            if(refl==1){
+                refl_amp = 1-sqrt(1.0-1.0/pow(1+altitude[i]/radius,2));
+                reflected_flux += refl_amp*apec_flux;
+            }
+            apec_flux *= 0;
+        }
+        if(refl==1){
+            CXX_reflect(energy, refl_parameters, spectrum_num, reflected_flux, flux_error, init_string);
+            flux += reflected_flux;
+        }
+    }
+};


### PR DESCRIPTION
These commits introduce an abstract base class which holds most of the functionality for MCVSPEC but leaves the "Set Abundance" function as a pure virtual method. This allows us to isolate the HEASoft dependancies to the XSPEC interface side of things allowing people to only install the python package if they so desire.